### PR TITLE
Add JSON marshal/unmarshal support

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -4,6 +4,8 @@ package collection
 type Collection[T any] interface {
 	Iterable[T]
 	Stringer
+	JSONMarshaler
+	JSONUnmarshaler
 
 	// Add adds the specified element to this collection.
 	Add(e T) bool

--- a/dict.go
+++ b/dict.go
@@ -5,6 +5,8 @@ type Dict[K comparable, V any] interface {
 	Iterable2[K, V]
 	DictIter[K, V]
 	Stringer
+	JSONMarshaler
+	JSONUnmarshaler
 
 	// Clear removes all key-value pairs in this dictionary.
 	Clear()

--- a/dict/dict_go123_test.go
+++ b/dict/dict_go123_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ghosind/go-assert"
 )
 
-func testDictIter(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictIter(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -23,7 +23,7 @@ func testDictIter(a *assert.Assertion, constructor dictTestConstructor) {
 	}
 }
 
-func testDictKeysIter(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictKeysIter(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -41,7 +41,7 @@ func testDictKeysIter(a *assert.Assertion, constructor dictTestConstructor) {
 	}
 }
 
-func testDictValuesIter(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictValuesIter(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)

--- a/dict/dict_test.go
+++ b/dict/dict_test.go
@@ -1,6 +1,7 @@
 package dict
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -10,7 +11,7 @@ import (
 	"github.com/ghosind/go-assert"
 )
 
-type dictTestConstructor func() collection.Dict[string, string]
+type dictConstructor func() collection.Dict[string, string]
 
 var testDataEn = map[string]string{
 	"zero":  "0",
@@ -38,7 +39,7 @@ var testDataZh = map[string]string{
 	"九": "9",
 }
 
-func testDict(a *assert.Assertion, constructor dictTestConstructor) {
+func testDict(a *assert.Assertion, constructor dictConstructor) {
 	testDictClear(a, constructor)
 	testDictClone(a, constructor)
 	testDictContainsKey(a, constructor)
@@ -57,9 +58,10 @@ func testDict(a *assert.Assertion, constructor dictTestConstructor) {
 	testDictString(a, constructor)
 	testDictValues(a, constructor)
 	testDictValuesIter(a, constructor)
+	testDictJSON(a, constructor)
 }
 
-func testDictClear(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictClear(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -72,7 +74,7 @@ func testDictClear(a *assert.Assertion, constructor dictTestConstructor) {
 	}
 }
 
-func testDictClone(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictClone(a *assert.Assertion, constructor dictConstructor) {
 	d1 := constructor()
 	for k, v := range testDataEn {
 		d1.Put(k, v)
@@ -81,7 +83,7 @@ func testDictClone(a *assert.Assertion, constructor dictTestConstructor) {
 	a.TrueNow(d1.Equals(d2))
 }
 
-func testDictContainsKey(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictContainsKey(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -94,7 +96,7 @@ func testDictContainsKey(a *assert.Assertion, constructor dictTestConstructor) {
 	}
 }
 
-func testDictEquals(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictEquals(a *assert.Assertion, constructor dictConstructor) {
 	d1 := constructor()
 	a.NotTrueNow(d1.Equals(nil))
 
@@ -126,7 +128,7 @@ func testDictEquals(a *assert.Assertion, constructor dictTestConstructor) {
 	a.NotTrueNow(d1.Equals(d3))
 }
 
-func testDictForEach(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictForEach(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -152,7 +154,7 @@ func testDictForEach(a *assert.Assertion, constructor dictTestConstructor) {
 	a.EqualNow(count, 1)
 }
 
-func testDictGet(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictGet(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -170,7 +172,7 @@ func testDictGet(a *assert.Assertion, constructor dictTestConstructor) {
 	}
 }
 
-func testDictGetDefault(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictGetDefault(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -186,7 +188,7 @@ func testDictGetDefault(a *assert.Assertion, constructor dictTestConstructor) {
 	}
 }
 
-func testDictIsEmpty(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictIsEmpty(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	a.TrueNow(d.IsEmpty())
 	for k, v := range testDataEn {
@@ -197,7 +199,7 @@ func testDictIsEmpty(a *assert.Assertion, constructor dictTestConstructor) {
 	a.TrueNow(d.IsEmpty())
 }
 
-func testDictKeys(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictKeys(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -209,7 +211,7 @@ func testDictKeys(a *assert.Assertion, constructor dictTestConstructor) {
 	}
 }
 
-func testDictPut(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictPut(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -218,7 +220,7 @@ func testDictPut(a *assert.Assertion, constructor dictTestConstructor) {
 	a.EqualNow(d.Size(), len(testDataEn))
 }
 
-func testDictRemove(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictRemove(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -230,7 +232,7 @@ func testDictRemove(a *assert.Assertion, constructor dictTestConstructor) {
 	a.EqualNow(d.Size(), 0)
 }
 
-func testDictReplace(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictReplace(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -249,7 +251,7 @@ func testDictReplace(a *assert.Assertion, constructor dictTestConstructor) {
 	}
 }
 
-func testDictSize(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictSize(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	a.EqualNow(d.Size(), 0)
 	for k, v := range testDataEn {
@@ -260,7 +262,7 @@ func testDictSize(a *assert.Assertion, constructor dictTestConstructor) {
 	a.EqualNow(d.Size(), 0)
 }
 
-func testDictString(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictString(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	for k, v := range testDataEn {
 		d.Put(k, v)
@@ -275,7 +277,7 @@ func testDictString(a *assert.Assertion, constructor dictTestConstructor) {
 	}
 }
 
-func testDictValues(a *assert.Assertion, constructor dictTestConstructor) {
+func testDictValues(a *assert.Assertion, constructor dictConstructor) {
 	d := constructor()
 	expectedValues := make([]string, 0, len(testDataEn))
 	for k, v := range testDataEn {
@@ -290,4 +292,27 @@ func testDictValues(a *assert.Assertion, constructor dictTestConstructor) {
 	sort.Strings(values)
 
 	a.EqualNow(expectedValues, values)
+}
+
+func testDictJSON(a *assert.Assertion, constructor dictConstructor) {
+	d1 := constructor()
+	for k, v := range testDataEn {
+		d1.Put(k, v)
+	}
+
+	b, err := d1.MarshalJSON()
+	a.NilNow(err)
+
+	d2 := constructor()
+	err = d2.UnmarshalJSON(b)
+	a.NilNow(err)
+	a.TrueNow(d1.Equals(d2))
+
+	d2.Clear()
+	b, err = json.Marshal(d1)
+	a.NilNow(err)
+
+	err = json.Unmarshal(b, d2)
+	a.NilNow(err)
+	a.TrueNow(d1.Equals(d2))
 }

--- a/dict/hash_dict.go
+++ b/dict/hash_dict.go
@@ -2,6 +2,7 @@ package dict
 
 import (
 	"bytes"
+	"encoding/json"
 
 	"github.com/ghosind/collection"
 	"github.com/ghosind/collection/internal"
@@ -163,4 +164,19 @@ func (m *HashDict[K, V]) Values() []V {
 	}
 
 	return arr
+}
+
+// MarshalJSON marshals the HashDict as a JSON object (map).
+func (m *HashDict[K, V]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[K]V(*m))
+}
+
+// UnmarshalJSON unmarshals a JSON object into the HashDict.
+func (m *HashDict[K, V]) UnmarshalJSON(b []byte) error {
+	var tmp map[K]V
+	if err := json.Unmarshal(b, &tmp); err != nil {
+		return err
+	}
+	*m = HashDict[K, V](tmp)
+	return nil
 }

--- a/dict/sync_dict.go
+++ b/dict/sync_dict.go
@@ -2,6 +2,7 @@ package dict
 
 import (
 	"bytes"
+	"encoding/json"
 	"sync"
 	"sync/atomic"
 
@@ -377,4 +378,27 @@ func (d *SyncDict[K, V]) Values() []V {
 	}
 
 	return keys
+}
+
+// MarshalJSON marshals the SyncDict as a JSON object (map).
+func (d *SyncDict[K, V]) MarshalJSON() ([]byte, error) {
+	m := make(map[K]V)
+	_ = d.ForEach(func(k K, v V) error {
+		m[k] = v
+		return nil
+	})
+	return json.Marshal(m)
+}
+
+// UnmarshalJSON unmarshals a JSON object into the SyncDict.
+func (d *SyncDict[K, V]) UnmarshalJSON(b []byte) error {
+	var tmp map[K]V
+	if err := json.Unmarshal(b, &tmp); err != nil {
+		return err
+	}
+	d.Clear()
+	for k, v := range tmp {
+		d.Put(k, v)
+	}
+	return nil
 }

--- a/dict/sync_dict.go
+++ b/dict/sync_dict.go
@@ -406,12 +406,18 @@ func (d *SyncDict[K, V]) UnmarshalJSON(b []byte) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	if d.expunged == nil {
+		// ensure expunged marker is initialized
+		d.expunged = new(V)
+	}
+
 	m := make(map[K]*internal.SyncEntry[V])
 	for k, v := range tmp {
 		m[k] = internal.NewSyncEntry(v, d.expunged)
 	}
 	d.read.Store(&internal.SyncReadOnly[K, V]{M: m})
 	d.dirty = nil
+	d.misses = 0
 
 	return nil
 }

--- a/encoding.go
+++ b/encoding.go
@@ -1,6 +1,15 @@
 package collection
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Stringer is an interface that wraps the basic String method.
 type Stringer fmt.Stringer
+
+// JSONMarshaler is an interface that wraps the basic MarshalJSON method.
+type JSONMarshaler json.Marshaler
+
+// JSONUnmarshaler is an interface that wraps the basic UnmarshalJSON method.
+type JSONUnmarshaler json.Unmarshaler

--- a/list/array_list.go
+++ b/list/array_list.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"bytes"
+	"encoding/json"
 
 	"github.com/ghosind/collection"
 	"github.com/ghosind/collection/internal"
@@ -302,4 +303,19 @@ func (l *ArrayList[T]) ToSlice() []T {
 	copy(arr, *l)
 
 	return arr
+}
+
+// MarshalJSON marshals the list as a JSON array.
+func (l *ArrayList[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(*l)
+}
+
+// UnmarshalJSON unmarshals a JSON array into the list.
+func (l *ArrayList[T]) UnmarshalJSON(b []byte) error {
+	var items []T
+	if err := json.Unmarshal(b, &items); err != nil {
+		return err
+	}
+	*l = ArrayList[T](items)
+	return nil
 }

--- a/list/copy_on_write_array_list.go
+++ b/list/copy_on_write_array_list.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"bytes"
+	"encoding/json"
 	"sync"
 
 	"github.com/ghosind/collection"
@@ -398,4 +399,22 @@ func (l *CopyOnWriteArrayList[T]) ToSlice() []T {
 	copy(slice, l.data)
 
 	return slice
+}
+
+// MarshalJSON marshals the copy-on-write list as a JSON array.
+func (l *CopyOnWriteArrayList[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.ToSlice())
+}
+
+// UnmarshalJSON unmarshals a JSON array into the copy-on-write list.
+func (l *CopyOnWriteArrayList[T]) UnmarshalJSON(b []byte) error {
+	var items []T
+	if err := json.Unmarshal(b, &items); err != nil {
+		return err
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.data = make([]T, len(items))
+	copy(l.data, items)
+	return nil
 }

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"encoding/json"
 	"errors"
 
 	"github.com/ghosind/collection"
@@ -35,6 +36,7 @@ func testList(a *assert.Assertion, constructor listConstructor) {
 	testListSize(a, constructor)
 	testListString(a, constructor)
 	testListToSlice(a, constructor)
+	testListJSON(a, constructor)
 }
 
 func testListAdd(a *assert.Assertion, constructor listConstructor) {
@@ -346,4 +348,25 @@ func testListToSlice(a *assert.Assertion, constructor listConstructor) {
 	a.EqualNow([]int{}, l.ToSlice())
 	l.AddAll(testData...)
 	a.EqualNow(testData, l.ToSlice())
+}
+
+func testListJSON(a *assert.Assertion, constructor listConstructor) {
+	l1 := constructor()
+	l1.AddAll(testData...)
+
+	b, err := l1.MarshalJSON()
+	a.NilNow(err)
+
+	l2 := constructor()
+	err = l2.UnmarshalJSON(b)
+	a.NilNow(err)
+	a.TrueNow(l1.Equals(l2))
+
+	l2.Clear()
+	b, err = json.Marshal(l1)
+	a.NilNow(err)
+
+	err = json.Unmarshal(b, l2)
+	a.NilNow(err)
+	a.TrueNow(l1.Equals(l2))
 }

--- a/set/hash_set.go
+++ b/set/hash_set.go
@@ -2,6 +2,7 @@ package set
 
 import (
 	"bytes"
+	"encoding/json"
 
 	"github.com/ghosind/collection"
 	"github.com/ghosind/collection/internal"
@@ -197,4 +198,22 @@ func (set *HashSet[T]) ToSlice() []T {
 	}
 
 	return slice
+}
+
+// MarshalJSON marshals the set as a JSON array.
+func (set *HashSet[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(set.ToSlice())
+}
+
+// UnmarshalJSON unmarshals a JSON array into the set.
+func (set *HashSet[T]) UnmarshalJSON(b []byte) error {
+	var items []T
+	if err := json.Unmarshal(b, &items); err != nil {
+		return err
+	}
+	*set = make(HashSet[T], len(items))
+	for _, v := range items {
+		(*set)[v] = empty{}
+	}
+	return nil
 }

--- a/set/hash_set_test.go
+++ b/set/hash_set_test.go
@@ -14,8 +14,4 @@ func TestHashSet(t *testing.T) {
 	}
 
 	testSet(a, constructor)
-
-	// TODO: Move to set_test.go
-	testSetRemoveIf(a, constructor)
-	testSetRetainAll(a, constructor)
 }

--- a/set/set_go123_test.go
+++ b/set/set_go123_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ghosind/go-assert"
 )
 
-func testSetIter(a *assert.Assertion, constructor setTestConstructor) {
+func testSetIter(a *assert.Assertion, constructor setConstructor) {
 	set1 := constructor()
 	set1.AddAll(testNums1...)
 

--- a/set/sync_set.go
+++ b/set/sync_set.go
@@ -2,6 +2,7 @@ package set
 
 import (
 	"bytes"
+	"encoding/json"
 	"sync"
 	"sync/atomic"
 
@@ -362,6 +363,24 @@ func (s *SyncSet[T]) ToSlice() []T {
 	}
 
 	return slice
+}
+
+// MarshalJSON marshals the SyncSet as a JSON array.
+func (s *SyncSet[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.ToSlice())
+}
+
+// UnmarshalJSON unmarshals a JSON array into the SyncSet.
+func (s *SyncSet[T]) UnmarshalJSON(b []byte) error {
+	var items []T
+	if err := json.Unmarshal(b, &items); err != nil {
+		return err
+	}
+	s.Clear()
+	if len(items) > 0 {
+		s.AddAll(items...)
+	}
+	return nil
 }
 
 // Clone returns a copy of this set.

--- a/set/sync_set.go
+++ b/set/sync_set.go
@@ -386,6 +386,7 @@ func (s *SyncSet[T]) UnmarshalJSON(b []byte) error {
 	}
 	s.read.Store(&internal.SyncReadOnly[T, empty]{M: m})
 	s.dirty = nil
+	s.misses = 0
 
 	return nil
 }

--- a/set/sync_set_test.go
+++ b/set/sync_set_test.go
@@ -14,8 +14,4 @@ func TestSyncSet(t *testing.T) {
 	}
 
 	testSet(a, constructor)
-
-	// TODO: Move to set_test.go
-	testSetRemoveIf(a, constructor)
-	testSetRetainAll(a, constructor)
 }


### PR DESCRIPTION
For #18, this PR adds `MarshalJSON` and `UnmarshalJSON` methods for the collections and dictionaries.

There are two ways to marshal/unmarshal the types to JSON:

- Invoke the `MarshalJSON` / `UnmarshalJSON`:

```go
s := set.NewHashSet[int]()
b, err := s.MarshalJSON()
```

- Use `json.Marshal`/`json.Unmarshal`:

```go
s := set.NewHashSet[int]()
b, err := json.Marshal(s)
```